### PR TITLE
removed default for the required parameters

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -288,12 +288,10 @@ def parse_args():
                           envvar='CONTAINER_REPO',
                           help="Container image repository")
     required.add_argument('-t', '--tag', action=EnvDefault, dest="tag",
-                          default='latest',
                           envvar='CONTAINER_TAG',
                           help="Container image tag")
     required.add_argument('-c', '--cloud-region', action=EnvDefault, dest="cloud",
                           envvar="FALCON_CLOUD_REGION",
-                          default='us-1',
                           choices=['us-1', 'us-2', 'eu-1'],
                           help="CrowdStrike cloud region")
     parser.add_argument('--json-report', dest="report", default=None,


### PR DESCRIPTION
Environment variables for the values cloud and tag do not overwrite the default value defined in def parse_args()

This can be verified by printing the contents of the variables in main when using environment variables.

This can be remedied by either commenting the line 267, removing the required from the parameter or removing the default value. Since this value should probably be defined almost always I decided to remove the default value.