### PR TITLE
fixed misconfigs alert

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -140,6 +140,7 @@ class ScanReport(dict):
     type_malware = "malware"
     type_secret = "secret"
     type_misconfig = 'misconfiguration'
+    type_cis = 'cis'
 
     def status_code(self):
         vuln_code = self.get_alerts_vuln()
@@ -225,7 +226,7 @@ class ScanReport(dict):
         if detections is not None:
             for detection in detections:
                 try:
-                    if detection['Detection']['Type'].lower() == self.type_misconfig:
+                    if detection['Detection']['Type'].lower() in [self.type_misconfig, self.type_cis]:
                         log.warning("Alert: Misconfiguration found")
                         det_code = ScanStatusCode.Success.value
                         break


### PR DESCRIPTION
Based on the CIS Type for a detection the misconfigurations would never alert. Here is a snippet of the raw JSON.

'Detections': [{'Detection': {'ID': '39e4d5', 'Type': '**CIS**', 'Name': '

Added another type and created an array for the misconfig check so it will alert on the CIS type. This would never alert unless the Type was "Misconfigurations" which I have never seen and I am not certain it exists.

Example:
INFO    Searching for misconfigurations in scan report...
WARNING Alert: Misconfiguration found
