### PR TITLE
Set type of optional arg retry_count

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -323,6 +323,7 @@ def parse_args():
     required.add_argument('-R', '--retry_count', action=EnvDefault, dest="retry_count",
                           default='10',
                           envvar='RETRY_COUNT',
+                          type=int,
                           help="Scan report retry count")
     args = parser.parse_args()
     logging.getLogger().setLevel(args.log_level)


### PR DESCRIPTION
The arg retry_count was not set as int which causes the following issue
```
Traceback (most recent call last):
    for count in range(retry_count):
TypeError: 'str' object cannot be interpreted as an integer
```