### PR TITLE
Fixing the missing environment for low level API call

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -47,7 +47,7 @@ class ScanImage(Exception):
         url_tag = "%s/%s" % (self.server_domain, self.repo)
 
         try:
-            dock_api_client = docker.APIClient()
+            dock_api_client = docker.APIClient(**docker.utils.kwargs_from_env())
         except AttributeError:
             dock_api_client = docker.Client()
 


### PR DESCRIPTION
Fixing the missing environment for low level API call

Some CI tools like (circleCI) are using a remote docker to build images,
This remote docker will use another base_url than localhost so we need to configure the low-level API.

Error on CircleCI, when trying to tag the image:
```
ERROR   Unknown error
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 665, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 387, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.8/http/client.py", line 1256, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1302, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1251, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1011, in _send_output
    self.send(msg)
  File "/usr/lib/python3.8/http/client.py", line 951, in send
    self.connect()
  File "/home/circleci/.local/lib/python3.8/site-packages/docker/transport/unixconn.py", line 33, in connect
    sock.connect(self.unix_socket)
FileNotFoundError: [Errno 2] No such file or directory
```