### PR TITLE
Add EnvDefault support for --json-report && --log-level

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -312,12 +312,12 @@ def parse_args():
                           default='500',
                           envvar='SCORE',
                           help="Vulnerability score threshold")
-    parser.add_argument('--json-report', action=EnvDefault, dest="report", 
+    parser.add_argument('--json-report', action=EnvDefault, dest="report",
                         envvar="JSON_REPORT",
                         default=None,
                         required=False,
                         help='Export JSON report to specified file')
-    parser.add_argument('--log-level', action=EnvDefault, dest='log_level', 
+    parser.add_argument('--log-level', action=EnvDefault, dest='log_level',
                         envvar="LOG_LEVEL",
                         default='INFO',
                         required=False,

--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -312,9 +312,15 @@ def parse_args():
                           default='500',
                           envvar='SCORE',
                           help="Vulnerability score threshold")
-    parser.add_argument('--json-report', dest="report", default=None,
+    parser.add_argument('--json-report', action=EnvDefault, dest="report", 
+                        envvar="JSON_REPORT",
+                        default=None,
+                        required=False,
                         help='Export JSON report to specified file')
-    parser.add_argument('--log-level', dest='log_level', default='INFO',
+    parser.add_argument('--log-level', action=EnvDefault, dest='log_level', 
+                        envvar="LOG_LEVEL",
+                        default='INFO',
+                        required=False,
                         choices=['DEBUG', 'INFO',
                                  'WARNING', 'ERROR', 'CRITICAL'],
                         help="Set the logging level")


### PR DESCRIPTION
Adding EnvDefault support to allow setting --json-report and --log-level via Environment Variables to use as part of a pipeline such as github actions or azure devops.