### PR TITLE
Default severity when null `Details` key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,163 @@
+# Domain
+report.json
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -181,13 +181,18 @@ class ScanReport(dict):
                 vuln = vulnerability['Vulnerability']
                 cve = vuln.get('CVEID', 'CVE-unknown')
                 details = vuln.get('Details', {})
-                cvss_v3 = details.get('cvss_v3_score', {})
-                severity = cvss_v3.get('severity')
-                if severity is None:
-                    cvss_v2 = details.get('cvss_v2_score', {})
-                    severity = cvss_v2.get('severity')
-                if severity is None:
-                    severity = details.get('severity', 'UNKNOWN')
+
+                if details is not None:
+                    cvss_v3 = details.get('cvss_v3_score', {})
+                    severity = cvss_v3.get('severity')
+                    if severity is None:
+                        cvss_v2 = details.get('cvss_v2_score', {})
+                        severity = cvss_v2.get('severity')
+                    if severity is None:
+                        severity = details.get('severity', '')
+                else:
+                    severity = ''
+
                 product = vuln.get('Product', {})
                 affects = product.get('PackageSource', product)
                 log.warning(

--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -180,9 +180,8 @@ class ScanReport(dict):
             for vulnerability in vulnerabilities:
                 vuln = vulnerability['Vulnerability']
                 cve = vuln.get('CVEID', 'CVE-unknown')
-                details = vuln.get('Details', {})
+                details = vuln.get('Details')
 
-                # verify details is a dict
                 if isinstance(details, dict):
                     cvss_v3 = details.get('cvss_v3_score', {})
                     severity = cvss_v3.get('severity')

--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -182,7 +182,8 @@ class ScanReport(dict):
                 cve = vuln.get('CVEID', 'CVE-unknown')
                 details = vuln.get('Details', {})
 
-                if details is not None:
+                # verify details is a dict
+                if isinstance(details, dict):
                     cvss_v3 = details.get('cvss_v3_score', {})
                     severity = cvss_v3.get('severity')
                     if severity is None:


### PR DESCRIPTION
This PR fixes #42 

Change simply checks if `details` is a dictionary if not it sets the severity to an empty string.

details no longer defaults to `{}` to  prevent unneeded checks

### Other

- adds a `.gitignore` file to allow codespaces to work (it tries to build the python package)