### PR TITLE
use default severity

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -183,13 +183,13 @@ class ScanReport(dict):
                 details = vuln.get('Details')
 
                 if isinstance(details, dict):
-                    cvss_v3 = details.get('cvss_v3_score', {})
-                    severity = cvss_v3.get('severity')
+                    severity = details.get('severity')
+                    if severity is None:
+                        cvss_v3 = details.get('cvss_v3_score', {})
+                        severity = cvss_v3.get('severity')
                     if severity is None:
                         cvss_v2 = details.get('cvss_v2_score', {})
-                        severity = cvss_v2.get('severity')
-                    if severity is None:
-                        severity = details.get('severity', '')
+                        severity = cvss_v2.get('severity', '')
                 else:
                     severity = ''
 


### PR DESCRIPTION
TLDR: for now `details['severity']` should be our source of truth

We are almost exclusively using `cvss_v2` score causing mismatches with the console/ui

Example:

```
"cvss_version": "3.1",
"source": "NVD",
"base_score": 7.8,
"severity": "HIGH",
"exploitability_score": 1.8,
"impact_score": 5.9,
"cvss_v2_score": {
    "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
    "base_score": 6.8,
    "severity": "MEDIUM",
    "exploitability_score": 8.6,
    "impact_score": 6.4
},
"cvss_v3_score": {
    "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
    "base_score": 7.8,
    "exploitability_score": 1.8,
    "impact_score": 5.9
},
  ```
  
  Would report `MEDIUM` as the severity because the `severity` key is missing in the `cvss_v3_score` dictionary.
  
However the `severity` reported in the `details` key is `3.1`: `"cvss_version": "3.1",` The impact _score etc all match `v3`

If v3 is fully missing from a CVE `severity` in the `details` key will use `v2` etc

