### PR TITLE
added retry package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9 AS base
 WORKDIR /app
 COPY cs_scanimage.py /app/cs_imagescan.py
 
-RUN pip install --user docker crowdstrike-falconpy
+RUN pip install --user retry docker crowdstrike-falconpy
 
 ENTRYPOINT ["python", "cs_imagescan.py"]
 


### PR DESCRIPTION
`retry` package missing from Dockerfile, causing runs to fail.

`Traceback (most recent call last):
  File "/app/cs_imagescan.py", line 49, in <module>
    from retry import retry
ModuleNotFoundError: No module named 'retry'
`