### PR TITLE
add missing dependency "retry" to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'docker',
-        'crowdstrike-falconpy'
+        'crowdstrike-falconpy',
+        'retry'
     ],
     extras_require={
         'devel': [


### PR DESCRIPTION
PR Adds retry dependency introduced in 2.1.1 to setup.py, downstream project Container-Image-Scan-Action is failing to run due to missing this dependency in setup. 

```
Run $GITHUB_ACTION_PATH/scan.sh -u '' -r <repo> -t <tag> -c 'us-1' -s '5000' -R '30' --log-level 'INFO' --json-report ''
Installing container-image-scan...
Traceback (most recent call last):
  File "/home/runner/work/<repo>/<workdir>/cs_scanimage.py", line 49, in <module>
    from retry import retry
ModuleNotFoundError: No module named 'retry'
```