### PR TITLE
updating requirements to remove Docker 7 Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ crowdstrike-falconpy
 setuptools>=59.6.0
 docker>=5.0.3
 retry>=0.9.2
+requests>=2.26.0
+urllib3>=1.26.0


### PR DESCRIPTION
The new docker package (version 7) has updated their requirement for urllib3 and requests:
https://github.com/docker/docker-py/blob/bd164f928ab82e798e30db455903578d06ba2070/setup.py#L12-L15

it's not yet blocking and causing issue for CI/CD pipeline but we can see the error during the image assessment setup : 

```
Collecting py<2.0.0,>=1.4.26
  Downloading py-1.11.0-py2.py3-none-any.whl (98 kB)
     |████████████████████████████████| 98 kB 111.8 MB/s 
ERROR: docker 7.0.0 has requirement requests>=2.26.0, but you'll have requests 2.22.0 which is incompatible.
ERROR: docker 7.0.0 has requirement urllib3>=1.26.0, but you'll have urllib3 1.25.8 which is incompatible.
Installing collected packages: crowdstrike-falconpy, setuptools, packaging, docker, decorator, py, retry
Successfully installed crowdstrike-falconpy-1.4.1 decorator-5.1.1 docker-7.0.0 packaging-24.0 py-1.11.0 retry-0.9.2 setuptools-69.1.1
```
