### PR TITLE
add podman support for image-based scanner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 crowdstrike-falconpy
 setuptools>=59.6.0
 docker>=5.0.3
+podman>=5.0.0
 retry>=0.9.2
 requests>=2.32.0
 urllib3>=1.26.0


### PR DESCRIPTION
The `quay.io/crowdstrike/container-image-scan:latest` image currently does not support podman.  This PR adds that functionality.

This is currently just a draft until fully working and tested.

Todo:
- fix the `scan_image.container_push()` function