### PR TITLE
add option for docker client timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,31 +51,31 @@ $ pip3 install -r requirements.txt
 
 ```shell
 $ python3 cs_scanimage.py --help
-usage: cs_scanimage.py [-h] -u CLIENT_ID -r REPO [-t TAG]
-                       [-c {us-1,us-2,eu-1,us-gov-1}] [-s SCORE]
-                       [--json-report REPORT]
-                       [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
-                       [-R RETRY_COUNT] [--plugin] [--user-agent USERAGENT]
+usage: cs_scanimage.py [-h] -u CLIENT_ID -r REPO [-t TAG] [-c {us-1,us-2,eu-1,us-gov-1}] [-s SCORE] [--json-report REPORT] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                       [-R RETRY_COUNT] [--plugin] [--user-agent USERAGENT] [--skip-push] [-T DOCKER_TIMEOUT]
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --json-report REPORT  Export JSON report to specified file
   --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         Set the logging level
   --plugin              Prints the report as json to stdout
   --user-agent USERAGENT
-                        HTTP User agent to use for API calls
+                        HTTP User agent to use for API calls. Default is 'container-image-scan'
+  --skip-push           Skip image push
+  -T, --docker-timeout DOCKER_TIMEOUT
+                        Set the timeout for the docker client
 
 required arguments:
-  -u CLIENT_ID, --clientid CLIENT_ID
+  -u, --clientid CLIENT_ID
                         Falcon OAuth2 API ClientID
-  -r REPO, --repo REPO  Container image repository
-  -t TAG, --tag TAG     Container image tag
-  -c {us-1,us-2,eu-1,us-gov-1}, --cloud-region {us-1,us-2,eu-1,us-gov-1}
+  -r, --repo REPO       Container image repository
+  -t, --tag TAG         Container image tag
+  -c, --cloud-region {us-1,us-2,eu-1,us-gov-1}
                         CrowdStrike cloud region
-  -s SCORE, --score_threshold SCORE
+  -s, --score_threshold SCORE
                         Vulnerability score threshold
-  -R RETRY_COUNT, --retry_count RETRY_COUNT
+  -R, --retry_count RETRY_COUNT
                         Scan report retry count
 ```
 

--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -434,6 +434,17 @@ def parse_args():
     parser.add_argument(
         "--skip-push", default=False, action="store_true", help="Skip image push"
     )
+    parser.add_argument(
+        "-T",
+        "--docker-timeout",
+        action=EnvDefault,
+        dest="docker_timeout",
+        envvar="DOCKER_TIMEOUT",
+        default=60,
+        required=False,
+        type=int,
+        help="Set the timeout for the docker client",
+    )
 
     args = parser.parse_args()
     logging.getLogger().setLevel(args.log_level)
@@ -449,6 +460,7 @@ def parse_args():
         args.plugin,
         args.useragent,
         args.skip_push,
+        args.docker_timeout,
     )
 
 
@@ -466,6 +478,7 @@ def main():  # pylint: disable=R0915
             plugin,
             useragent,
             skip_push,
+            docker_timeout,
         ) = parse_args()
         client_secret = env.get("FALCON_CLIENT_SECRET")
         if client_secret is None:
@@ -478,7 +491,7 @@ def main():  # pylint: disable=R0915
                 import docker  # pylint: disable=C0415
             except ModuleNotFoundError:
                 import podman as docker  # pylint: disable=C0415
-            client = docker.from_env()
+            client = docker.from_env(timeout=docker_timeout)
             useragent = "%s/%s" % (useragent, VERSION)
             scan_image = ScanImage(client_id, client_secret, repo, tag, client, cloud)
             scan_image.container_tag()


### PR DESCRIPTION
The docker client has a default timeout of 60 seconds. This can cause a timeout if you are trying to push big images. This allows the user to set a custom timeout if needed.