### PR TITLE
Replace retry package with tenacity

### DIFF
--- a/cs_scanimage.py
+++ b/cs_scanimage.py
@@ -45,7 +45,7 @@ from enum import Enum
 import time
 import getpass
 from falconpy import FalconContainer, ContainerBaseURL
-from retry import retry
+from tenacity import retry, stop_after_attempt, stop_after_delay
 
 
 logging.basicConfig(stream=sys.stdout, format="%(levelname)-8s%(message)s")
@@ -119,7 +119,7 @@ class ScanImage(Exception):
                 raise
 
     # Step 3: perform container push using the repo and tag supplied
-    @retry(TimeoutError, tries=5, delay=5)
+    @retry(stop=(stop_after_delay(5) | stop_after_attempt(5)))
     def container_push(self):
         image_str = "%s/%s:%s" % (self.server_domain, self.repo, self.tag)
         log.info("Performing container push to %s", image_str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ crowdstrike-falconpy
 setuptools>=59.6.0
 docker>=5.0.3
 podman>=5.0.0
-retry>=0.9.2
+tenacity>=9.1.0
 requests>=2.32.0
 urllib3>=2.2.2
 certifi>=2024.7.4


### PR DESCRIPTION
The `retry` package is old and unmaintained. It depends on a vulnerable `py` package, which is even older.

This PR replaces the package with [tenacity](https://github.com/jd/tenacity), a modern replacement.